### PR TITLE
Add Industrial style preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The starter theme includes an integration of:
 
 - Set the default page width to 1440px and tweaked the desktop page width range to be 1200px to 1600px with a step adjustment of 10px (standard desktop width used at Trellis and allows for more fine tuning)
 - There is a page template called `noindexnofollow` with the meta tag `noindex, nofollow` for any pages that need to be hidden from search engine site crawlers
+- Added an optional "Industrial" preset with its own `industrial.css` file. The stylesheet loads only when this preset is selected in the theme settings.
 
 ## Steps to Start Using this Starter Theme
 

--- a/assets/industrial.css
+++ b/assets/industrial.css
@@ -1,0 +1,12 @@
+/* Custom styles for Industrial preset */
+
+body {
+  font-family: 'Roboto', Arial, sans-serif;
+}
+
+.button:not([disabled]):hover,
+.shopify-payment-button__button--unbranded:hover {
+  transition: box-shadow 0.3s ease, transform 0.3s ease;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+  transform: translateY(-2px);
+}

--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -3,6 +3,7 @@
   "presets": {
     "Default": {
       "logo_width": 90,
+      "theme_preset": "Default",
       "color_schemes": {
         "scheme-1": {
           "settings": {

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -8,6 +8,21 @@
     "theme_support_url": "https://support.shopify.com/"
   },
   {
+    "name": "Theme style",
+    "settings": [
+      {
+        "type": "select",
+        "id": "theme_preset",
+        "label": "Theme style preset",
+        "options": [
+          { "value": "Default", "label": "Default" },
+          { "value": "Industrial", "label": "Industrial" }
+        ],
+        "default": "Default"
+      }
+    ]
+  },
+  {
     "name": "t:settings_schema.logo.name",
     "settings": [
       {

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -261,6 +261,9 @@
     {% comment %}swap the order of the stylesheets to have Tailwind classes take precedence over the base Dawn styles{% endcomment %}
     {{ 'app.css' | asset_url | stylesheet_tag }}
     {{ 'base.css' | asset_url | stylesheet_tag }}
+    {% if settings.theme_preset == 'Industrial' %}
+      {{ 'industrial.css' | asset_url | stylesheet_tag }}
+    {% endif %}
     <link rel='stylesheet' href='{{ 'component-cart-items.css' | asset_url }}' media='print' onload="this.media='all'">
 
     {%- if settings.cart_type == 'drawer' -%}


### PR DESCRIPTION
## Summary
- add new industrial stylesheet with hover transitions and subtle shadows
- include industrial.css when the `Industrial` preset is active
- allow selecting the preset in theme settings
- document this enhancement in README

## Testing
- `npm install`
- `npx -y lint-staged`

------
https://chatgpt.com/codex/tasks/task_b_68423cb3b60c8323ba105c3ce9559b14